### PR TITLE
Add paginated table view for ports

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -35,6 +35,7 @@ func main() {
 	api := r.Group("/api/v1")
 	{
 		api.GET("/ports", getPorts)
+		api.GET("/ports_paginated", getPaginatedPorts)
 		api.POST("/ports/:id/lock", lockPort)
 		api.DELETE("/ports/:id/lock", unlockPort)
 		api.GET("/ports/:id/status", getPortStatus)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,7 +42,30 @@
                         <option value="locked">Locked</option>
                     </select>
                 </div>
+                <div class="view-toggle">
+                    <button id="card-view-btn" class="btn btn-secondary">Card View</button>
+                    <button id="table-view-btn" class="btn btn-secondary">Table View</button>
+                </div>
                 <div id="ports-grid" class="ports-grid"></div>
+                <div id="ports-table-section" style="display:none;">
+                    <table id="ports-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Category</th>
+                                <th>Description</th>
+                                <th>Status</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                    <div id="pagination" class="pagination">
+                        <button id="prev-page" class="btn btn-secondary">Prev</button>
+                        <span id="page-info"></span>
+                        <button id="next-page" class="btn btn-secondary">Next</button>
+                    </div>
+                </div>
             </div>
         </main>
 

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -188,6 +188,34 @@ header h1 {
     background: #555;
 }
 
+.view-toggle {
+    margin-bottom: 15px;
+}
+
+#ports-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#ports-table th,
+#ports-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+#ports-table th {
+    background: #f2f2f2;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
 .modal {
     display: none;
     position: fixed;


### PR DESCRIPTION
## Summary
- backend: add pagination endpoint to list ports
- frontend: add table view with pagination and toggle between card and table views
- frontend: style table and pagination controls

## Testing
- `node -c frontend/static/js/app.js`
- `go build .` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_686b0dc73bbc8329a71939f4ff0c8d5e