### PR TITLE
Add sidebar admin layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,18 @@
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
-    <div class="container">
+    <div class="admin-container">
+        <aside class="sidebar">
+            <h2>Ports Admin</h2>
+            <nav>
+                <ul>
+                    <li><a href="#">Dashboard</a></li>
+                    <li><a href="#">Ports</a></li>
+                    <li><a href="#">Settings</a></li>
+                </ul>
+            </nav>
+        </aside>
+        <div class="container">
         <header>
             <h1>🐉 DragonFly BSD Ports Coordinator</h1>
             <p>Coordinate development of broken ports</p>
@@ -89,6 +100,7 @@
             </div>
         </div>
     </div>
+</div>
 
     <script src="/static/js/app.js"></script>
 </body>

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -10,10 +10,49 @@ body {
     color: #333;
 }
 
+.admin-container {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 220px;
+    background: #263238;
+    color: #fff;
+    padding: 20px 0;
+}
+
+.sidebar h2 {
+    text-align: center;
+    margin-bottom: 20px;
+    font-size: 1.4em;
+}
+
+.sidebar ul {
+    list-style: none;
+    padding: 0;
+}
+
+.sidebar li {
+    margin-bottom: 10px;
+}
+
+.sidebar a {
+    color: #fff;
+    text-decoration: none;
+    display: block;
+    padding: 10px 20px;
+}
+
+.sidebar a:hover {
+    background: #37474f;
+}
+
 .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
+    flex: 1;
 }
 
 header {


### PR DESCRIPTION
## Summary
- add a sidebar to the index page so the UI resembles an admin panel
- style the new admin layout

## Testing
- `gofmt -w handlers.go main.go models.go`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686b10ca5d5c832999416c99d508b4a0